### PR TITLE
ensure type int for status code

### DIFF
--- a/src/Model/Common/StatusInformation.php
+++ b/src/Model/Common/StatusInformation.php
@@ -20,6 +20,7 @@ class StatusInformation
      * of returned status codes is contained in the list.
      *
      * @var int $statusCode
+     * Note: in PHP 7.4 this will become "protected int $statusCode"
      */
     protected $statusCode;
 
@@ -42,7 +43,7 @@ class StatusInformation
      */
     public function getStatusCode(): int
     {
-        return $this->statusCode;
+        return intval($this->statusCode);
     }
 
     /**

--- a/src/Model/Common/StatusInformation.php
+++ b/src/Model/Common/StatusInformation.php
@@ -19,8 +19,7 @@ class StatusInformation
      * A value greater than zero indicates that an error occurred. The detailed mapping and explanation
      * of returned status codes is contained in the list.
      *
-     * @var int $statusCode
-     * Note: in PHP 7.4 this will become "protected int $statusCode"
+     * @var int|string $statusCode
      */
     protected $statusCode;
 
@@ -43,7 +42,7 @@ class StatusInformation
      */
     public function getStatusCode(): int
     {
-        return intval($this->statusCode);
+        return (int) $this->statusCode;
     }
 
     /**


### PR DESCRIPTION
This simple change fixes a " Label could not be created: Web service request failed."
caused by a "ServiceException Return value of Dhl\Sdk\Paket\Bcs\Model\Common\StatusInformation::getStatusCode() must be of the type int, string returned"
As far as we can see, It should not have any adverse effects.

We did not force the field $statusCode to be "int" to keep the source code compatible to PHP versions prior 7.4 .
For our PHP 7.4 system we did that change but it did not yield an more insight into where the string-valued "statusCode" was set. Presumably in some code that can convert the string representatio of the number "0" into an integer on the fly.

The change has been validated in production and dhl/module-carrier-paket/Model/Pipeline/CreateShipments now works for us.