### PR TITLE
psr update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/http-factory-implementation": "^1.0.0",
         "psr/http-message": "^1.0.0",
         "psr/http-message-implementation": "^1.0.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1 | ^2 | ^3"
     },
     "require-dev": {
         "ext-simplexml": "*",

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -17,7 +17,7 @@ use Dhl\Sdk\Paket\Bcs\Http\HttpServiceFactory;
 use Dhl\Sdk\Paket\Bcs\Serializer\ClassMap;
 use Dhl\Sdk\Paket\Bcs\Soap\SoapServiceFactory;
 use Http\Discovery\Exception\NotFoundException;
-use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Log\LoggerInterface;
 
 class ServiceFactory implements ServiceFactoryInterface
@@ -54,7 +54,7 @@ class ServiceFactory implements ServiceFactoryInterface
         bool $sandboxMode = false
     ): ShipmentServiceInterface {
         try {
-            $httpClient = HttpClientDiscovery::find();
+            $httpClient = Psr18ClientDiscovery::find();
         } catch (NotFoundException $exception) {
             throw ServiceExceptionFactory::createServiceException($exception);
         }


### PR DESCRIPTION
The psr standards have progressed and the logging interface now contains typing information.
Since this is not implemented but just used here, there is no harm in allowing newer version.

There is also the issue of the `HttpClientDiscovery` class, which is deprecated and searches for the depcrecated `HttpClient` interface that no modern http client implements. The `HttpServiceFactory` was already hinting to the more modern `ClientInterface` so using the more modern `Psr18ClientDiscovery` should bring no harm and the `HttpClient` interface extends the `ClientInterface` so there should be no compatibility issue.